### PR TITLE
Felixm/351 update

### DIFF
--- a/install_lightbits.sh
+++ b/install_lightbits.sh
@@ -14,6 +14,7 @@
 #                    added support for installing with and to RHEL 9 family OS
 # 06-Nov-2023 [FM]   added support for Lightbits v3.4.2 and v3.5.1
 #                    fixed logrotate for Alma
+#                    added i4i.4xlarge to AWS list
 #
 
 INSTALL_LIGHTBITS_VERSION="V1.03"
@@ -67,7 +68,7 @@ DisplayHelp()
     Syntax: ${0##*/} [-m|n|i|u|p|k|t|v|c]
     options:                                     example:
     m    Configure mode.                         configure, install
-    n    Node type.                              l16s_v3, l32s_v3, l64s_v3, l80s_v3, i3en.6xlarge, i3en.12xlarge, i3en.24xlarge, i3en.metal, i4i.8xlarge, i4i.16xlarge, i4i.32xlarge, i4i.metal, generic
+    n    Node type.                              l16s_v3, l32s_v3, l64s_v3, l80s_v3, i3en.6xlarge, i3en.12xlarge, i3en.24xlarge, i3en.metal, i4i.4xlarge, i4i.8xlarge, i4i.16xlarge, i4i.32xlarge, i4i.metal, generic
     i    List of server IPs.                     \"10.0.0.1,10.0.0.2,10.0.0.3\"
     u    Username.                               root
     p    Password - use SINGLE quotes ''.        'p@ssword12345!!'
@@ -270,7 +271,7 @@ CheckConfigure()
     # Check that the vm type is within the accepted list
     CheckVMType()
     {
-        nodeList=("l16s_v3" "l32s_v3" "l64s_v3" "l80s_v3" "i3en.6xlarge" "i3en.12xlarge" "i3en.24xlarge" "i3en.metal" "i4i.8xlarge" "i4i.16xlarge" "i4i.32xlarge" "i4i.metal" "generic")
+        nodeList=("l16s_v3" "l32s_v3" "l64s_v3" "l80s_v3" "i3en.6xlarge" "i3en.12xlarge" "i3en.24xlarge" "i3en.metal" "i4i.4xlarge" "i4i.8xlarge" "i4i.16xlarge" "i4i.32xlarge" "i4i.metal" "generic")
         containsNode=0
         for nodeType in "${nodeList[@]}"; do
             if [ "${nodeType}" = "${node}" ]; then
@@ -598,6 +599,9 @@ EOL
                         ;;
                     i3en.metal)
                         noDisks=8
+                        ;;
+                    i4i.8xlarge)
+                        noDisks=1
                         ;;
                     i4i.8xlarge)
                         noDisks=2

--- a/install_lightbits.sh
+++ b/install_lightbits.sh
@@ -812,7 +812,7 @@ RunMode()
     # Check that a supported mode has been provided
     CheckMode()
     {
-        modeList=("configure" "install" "cleanup)
+        modeList=("configure" "install" "cleanup")
         containsMode=0
         for modeType in "${modeList[@]}"; do
             if [ "${modeType}" = "${mode}" ]; then

--- a/install_lightbits.sh
+++ b/install_lightbits.sh
@@ -241,6 +241,7 @@ ConfigureInstaller()
         else
             echo "OS not supported for install, please use ${ALLOWED_OS}"
             exit 1
+        fi
     }
 
     CheckInstallerOS

--- a/install_lightbits.sh
+++ b/install_lightbits.sh
@@ -618,7 +618,7 @@ EOL
                     i3en.metal)
                         noDisks=8
                         ;;
-                    i4i.8xlarge)
+                    i4i.4xlarge)
                         noDisks=1
                         ;;
                     i4i.8xlarge)

--- a/install_lightbits.sh
+++ b/install_lightbits.sh
@@ -12,6 +12,8 @@
 # 08-Aug-2023 [OE]   add jq install also in CheckVersion
 # 11-Sep-2023 [FM]   added support for Lightbits v3.4.1 and therefore userspace
 #                    added support for installing with and to RHEL 9 family OS
+# 06-Nov-2023 [FM]   added support for Lightbits v3.4.2 and v3.5.1
+#                    fixed logrotate for Alma
 #
 
 INSTALL_LIGHTBITS_VERSION="V1.03"
@@ -45,6 +47,14 @@ LB_JSON="{\"lbVersions\": [
     {
         \"versionName\": \"lightos-3-4-1-rhl-8\",
         \"versionLightApp\": \"light-app-install-environment-v3.4.1~b1397.tgz\"
+    },
+    {
+        \"versionName\": \"lightos-3-4-2-rhl-8\",
+        \"versionLightApp\": \"light-app-install-environment-v3.4.2~b1423.tgz\"
+    },
+    {
+        \"versionName\": \"lightos-3-5-1-rhl-8\",
+        \"versionLightApp\": \"light-app-install-environment-v3.5.1~b1443.tgz\"
     }
 ]}"
 CURRENT_DIR=`pwd`
@@ -63,17 +73,17 @@ DisplayHelp()
     p    Password - use SINGLE quotes ''.        'p@ssword12345!!'
     k    Path to key.                            /home/root/keys/key.pem
     t    Lightbits Repository token.             QWCEWVDASADSSsSD
-    v    Lightbits Version.                      lightos-3-1-2-rhl-86, lightos-3-2-1-rhl-86, lightos-3-3-1-rhl-8, lightos-3-4-1-rhl-8
+    v    Lightbits Version.                      lightos-3-3-1-rhl-8, lightos-3-4-1-rhl-8, lightos-3-4-2-rhl-8, lightos-3-5-1-rhl-8
     c    Lightbits Cluster Name.                 aws-cluster-0
     d    Data IPs                                optional to provide data interface ips required for generic node case \"10.0.0.1,10.0.0.2,10.0.0.3\"
 
     Full Example (Azure with password):
-    ${0##*/} -m configure -n l16s_v3 -i \"10.0.0.1,10.0.0.2,10.0.0.3\" -u azureuser -p \'password\' -t QWCEWVDASADSSsSD -v lightos-3-2-1-rhl-86 -c test-cluster
-    ${0##*/} -m install -c test-cluster -v lightos-3-2-1-rhl-86
+    ${0##*/} -m configure -n l16s_v3 -i \"10.0.0.1,10.0.0.2,10.0.0.3\" -u azureuser -p \'password\' -t QWCEWVDASADSSsSD -v lightos-3-5-1-rhl-8 -c test-cluster
+    ${0##*/} -m install -c test-cluster -v lightos-3-5-1-rhl-8
 
     Full Example (AWS with keys):
-    ${0##*/} -m configure -n i3en.6xlarge -i \"10.0.0.1,10.0.0.2,10.0.0.3\" -u ec2-user -k /home/ec2-user/key.pem -t QWCEWVDASADSSsSD -v lightos-3-2-1-rhl-86 -c test-cluster
-    ${0##*/} -m install -c test-cluster -v lightos-3-2-1-rhl-86
+    ${0##*/} -m configure -n i3en.6xlarge -i \"10.0.0.1,10.0.0.2,10.0.0.3\" -u ec2-user -k /home/ec2-user/key.pem -t QWCEWVDASADSSsSD -v lightos-3-5-1-rhl-8 -c test-cluster
+    ${0##*/} -m install -c test-cluster -v lightos-3-5-1-rhl-8
 
     Full Example (generic/pre-allocated-lab-servers, with password):
     ${0##*/} -m configure -n generic -i \"rack99-server01,rack99-server02,rack99-server03\" -u azureuser -p \'password\' -t QWCEWVDASADSSsSD -v lightos-3-3-x-ga -c test-cluster -d \"10.109.11.251,10.109.11.252,10.109.11.253\"
@@ -399,7 +409,7 @@ PrepTargets()
     if [[ ${userspace} -eq null ]]; then # Use a different config for userspace
         echo "Userspace release"
         read -r -d '' targetPrepCommands << EOF
-sudo yum install -qy wget iptables
+sudo yum install -qy wget iptables logrotate
 
 sudo sed -i 's/^SELINUX=.*$/SELINUX=disabled/' /etc/selinux/config
 

--- a/install_lightbits.sh
+++ b/install_lightbits.sh
@@ -774,7 +774,7 @@ RunInstall()
     RunAnsibleInstall
 }
 
-RunAnsibleInstall()
+RunAnsibleCleanup()
 {
     echo "Do some cleanups..."
     # Clean up any old certs and JWTs
@@ -797,9 +797,9 @@ RunAnsibleInstall()
 
 RunCleanup()
 {
-    # Run program in install mode
+    # Run program in cleanup mode
     echo "#############"
-    echo "Run Install"
+    echo "Run Cleanup"
     echo "#############"
     CheckClusterName
     CheckVersion

--- a/install_lightbits.sh
+++ b/install_lightbits.sh
@@ -15,6 +15,7 @@
 # 06-Nov-2023 [FM]   added support for Lightbits v3.4.2 and v3.5.1
 #                    fixed logrotate for Alma
 #                    added i4i.4xlarge to AWS list
+#                    fixed epel-release install in RHEL & Alma
 #
 
 INSTALL_LIGHTBITS_VERSION="V1.03"
@@ -212,7 +213,7 @@ ConfigureInstaller()
     {
         echo "Installing tools"
         sudo yum install jq -y
-        sudo yum -qy install epel-release
+        sudo yum -qy install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         sudo yum install -qy yum-utils pssh sshpass
 
         echo "Add docker repo"


### PR DESCRIPTION
FYI @ofir-lb 

- Added support for cleanup
- Added support for 3.4.2
- Added support for 3.5.1
- Fixed issue where logrotate wouldn't configure on AlmaLinux
- Fixed epel-release install for installers on v8
- Added functionality that checks installer OS is rhel, rocky, alma or centos