### PR TITLE
Fix spelling mistake which passed incorrect data IPs to server files.

### DIFF
--- a/install_lightbits.sh
+++ b/install_lightbits.sh
@@ -693,7 +693,7 @@ EOL
         }
         CalculateNoDisks
         serverCount=0
-        if [[ -z "${dataIps}" ]]; then # Use management IPs in host file
+        if [[ -z "${dataIPs}" ]]; then # Use management IPs in host file
             for host in "${serverIPs[@]}"; do
                 CreateServerFile "server${serverCount}" "${host}"
                 serverCount=$((serverCount+1))


### PR DESCRIPTION
Parameter was "dataIps" but should have been "dataIPs"